### PR TITLE
Feature : 그룹 생성/입장, 그룹장소목록조회, 태그목록조회, 그룹멤버조회, 프리셋 집안일 목록 조회, 집안일 추가, 사용자 그룹 조회

### DIFF
--- a/src/main/java/team1/housework/auth/aop/Auth.java
+++ b/src/main/java/team1/housework/auth/aop/Auth.java
@@ -1,0 +1,4 @@
+package team1.housework.auth.aop;
+
+public @interface Auth {
+}

--- a/src/main/java/team1/housework/character/entity/Character.java
+++ b/src/main/java/team1/housework/character/entity/Character.java
@@ -1,0 +1,23 @@
+package team1.housework.character.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Character {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	private String imageUrl;
+}

--- a/src/main/java/team1/housework/character/repository/CharacterRepository.java
+++ b/src/main/java/team1/housework/character/repository/CharacterRepository.java
@@ -1,0 +1,6 @@
+package team1.housework.character.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CharacterRepository extends JpaRepository<Character, Long> {
+}

--- a/src/main/java/team1/housework/character/service/CharacterService.java
+++ b/src/main/java/team1/housework/character/service/CharacterService.java
@@ -1,0 +1,20 @@
+package team1.housework.character.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.character.repository.CharacterRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CharacterService {
+
+	private final CharacterRepository characterRepository;
+
+	public Boolean existsById(Long id) {
+		return characterRepository.existsById(id);
+	}
+
+}

--- a/src/main/java/team1/housework/group/controller/GroupController.java
+++ b/src/main/java/team1/housework/group/controller/GroupController.java
@@ -16,13 +16,12 @@ import team1.housework.group.service.dto.EnterRequest;
 import team1.housework.group.service.dto.EnterResponse;
 import team1.housework.group.service.dto.GroupRequest;
 import team1.housework.group.service.dto.GroupResponse;
-import team1.housework.group.service.dto.HouseWorkResponse;
 import team1.housework.group.service.dto.HouseWorkSaveRequest;
 import team1.housework.group.service.dto.MemberResponse;
+import team1.housework.group.service.dto.MyGroupResponse;
 import team1.housework.group.service.dto.PlaceResponse;
 import team1.housework.group.service.dto.TagResponse;
 import team1.housework.member.entity.Member;
-import team1.housework.group.service.dto.MyGroupResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -63,7 +62,7 @@ public class GroupController {
 	}
 
 	@PostMapping("/{groupId}/house-work")
-	public HouseWorkResponse saveHouseWork(@PathVariable Long groupId, @RequestBody HouseWorkSaveRequest request) {
-		return groupService.saveHouseWork(groupId, request);
+	public void saveHouseWork(@PathVariable Long groupId, @RequestBody HouseWorkSaveRequest request) {
+		groupService.saveHouseWork(groupId, request);
 	}
 }

--- a/src/main/java/team1/housework/group/controller/GroupController.java
+++ b/src/main/java/team1/housework/group/controller/GroupController.java
@@ -1,0 +1,56 @@
+package team1.housework.group.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.auth.aop.Auth;
+import team1.housework.group.service.GroupService;
+import team1.housework.group.service.dto.EnterRequest;
+import team1.housework.group.service.dto.EnterResponse;
+import team1.housework.group.service.dto.GroupRequest;
+import team1.housework.group.service.dto.GroupResponse;
+import team1.housework.group.service.dto.MemberResponse;
+import team1.housework.group.service.dto.PlaceResponse;
+import team1.housework.group.service.dto.TagResponse;
+import team1.housework.member.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class GroupController {
+
+	private final GroupService groupService;
+
+	//TODO: 액세스토큰 파싱해 Member 바인딩
+	@PostMapping
+	public GroupResponse save(@Auth Member member, @RequestBody GroupRequest groupRequest) {
+		return groupService.save(member, groupRequest);
+	}
+
+	@PostMapping("/enter")
+	public EnterResponse enter(@Auth Member member, @RequestBody EnterRequest enterRequest) {
+		return groupService.enter(member, enterRequest);
+	}
+
+	@GetMapping("/{groupId}/places")
+	public List<PlaceResponse> getPlaces(@PathVariable Long groupId) {
+		return groupService.getPlaces(groupId);
+	}
+
+	@GetMapping("/{groupId}/tags")
+	public List<TagResponse> getTags(@PathVariable Long groupId) {
+		return groupService.getTags(groupId);
+	}
+
+	@GetMapping("/{groupId}/members")
+	public List<MemberResponse> getMembers(@PathVariable Long groupId) {
+		return groupService.getMembers(groupId);
+	}
+}

--- a/src/main/java/team1/housework/group/controller/GroupController.java
+++ b/src/main/java/team1/housework/group/controller/GroupController.java
@@ -16,10 +16,13 @@ import team1.housework.group.service.dto.EnterRequest;
 import team1.housework.group.service.dto.EnterResponse;
 import team1.housework.group.service.dto.GroupRequest;
 import team1.housework.group.service.dto.GroupResponse;
+import team1.housework.group.service.dto.HouseWorkResponse;
+import team1.housework.group.service.dto.HouseWorkSaveRequest;
 import team1.housework.group.service.dto.MemberResponse;
 import team1.housework.group.service.dto.PlaceResponse;
 import team1.housework.group.service.dto.TagResponse;
 import team1.housework.member.entity.Member;
+import team1.housework.group.service.dto.MyGroupResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,5 +55,15 @@ public class GroupController {
 	@GetMapping("/{groupId}/members")
 	public List<MemberResponse> getMembers(@PathVariable Long groupId) {
 		return groupService.getMembers(groupId);
+	}
+
+	@GetMapping("/my-group")
+	public MyGroupResponse getMyGroup(@Auth Member member) {
+		return groupService.getMyGroup(member);
+	}
+
+	@PostMapping("/{groupId}/house-work")
+	public HouseWorkResponse saveHouseWork(@PathVariable Long groupId, @RequestBody HouseWorkSaveRequest request) {
+		return groupService.saveHouseWork(groupId, request);
 	}
 }

--- a/src/main/java/team1/housework/group/entity/Group.java
+++ b/src/main/java/team1/housework/group/entity/Group.java
@@ -1,0 +1,28 @@
+package team1.housework.group.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Group {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long characterId;
+
+	private String inviteCode;
+
+	public Group(Long characterId, String inviteCode) {
+		this.characterId = characterId;
+		this.inviteCode = inviteCode;
+	}
+}

--- a/src/main/java/team1/housework/group/entity/GroupMember.java
+++ b/src/main/java/team1/housework/group/entity/GroupMember.java
@@ -1,0 +1,32 @@
+package team1.housework.group.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupMember {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "group_id")
+	private Group group;
+
+	private Long memberId;
+
+	public GroupMember(Group group, Long memberId) {
+		this.group = group;
+		this.memberId = memberId;
+	}
+}

--- a/src/main/java/team1/housework/group/entity/HouseWork.java
+++ b/src/main/java/team1/housework/group/entity/HouseWork.java
@@ -1,0 +1,44 @@
+package team1.housework.group.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HouseWork {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	@ManyToOne
+	@JoinColumn(name = "place_id")
+	private Place place;
+
+	@ManyToOne
+	@JoinColumn(name = "group_id")
+	private Group group;
+
+	private LocalDate taskDate;
+
+	private boolean isNotified;
+
+	public HouseWork(String name, Place place, Group group, LocalDate taskDate, boolean isNotified) {
+		this.name = name;
+		this.place = place;
+		this.group = group;
+		this.taskDate = taskDate;
+		this.isNotified = isNotified;
+	}
+}

--- a/src/main/java/team1/housework/group/entity/HouseWorkTag.java
+++ b/src/main/java/team1/housework/group/entity/HouseWorkTag.java
@@ -1,7 +1,5 @@
 package team1.housework.group.entity;
 
-import java.time.LocalDate;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,32 +13,21 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class HouseWork {
+public class HouseWorkTag {
 
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String name;
+	@ManyToOne
+	@JoinColumn(name = "house_work_id")
+	private HouseWork houseWork;
 
 	@ManyToOne
-	@JoinColumn(name = "place_id")
-	private Place place;
+	@JoinColumn(name = "tag_id")
+	private Tag tag;
 
-	@ManyToOne
-	@JoinColumn(name = "group_id")
-	private Group group;
-
-
-
-	private LocalDate taskDate;
-
-	private boolean isNotified;
-
-	public HouseWork(String name, Place place, Group group, LocalDate taskDate, boolean isNotified) {
-		this.name = name;
-		this.place = place;
-		this.group = group;
-		this.taskDate = taskDate;
-		this.isNotified = isNotified;
+	public HouseWorkTag(HouseWork houseWork, Tag tag) {
+		this.houseWork = houseWork;
+		this.tag = tag;
 	}
 }

--- a/src/main/java/team1/housework/group/entity/Place.java
+++ b/src/main/java/team1/housework/group/entity/Place.java
@@ -1,0 +1,32 @@
+package team1.housework.group.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	@ManyToOne
+	@JoinColumn(name = "group_id")
+	private Group group;
+
+	public Place(String name, Group group) {
+		this.name = name;
+		this.group = group;
+	}
+}

--- a/src/main/java/team1/housework/group/entity/Tag.java
+++ b/src/main/java/team1/housework/group/entity/Tag.java
@@ -1,0 +1,31 @@
+package team1.housework.group.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	@ManyToOne
+	@JoinColumn(name = "group_id")
+	private Group group;
+
+	public Tag(String name, Group group) {
+		this.name = name;
+		this.group = group;
+	}
+}

--- a/src/main/java/team1/housework/group/repository/GroupMemberRepository.java
+++ b/src/main/java/team1/housework/group/repository/GroupMemberRepository.java
@@ -1,0 +1,12 @@
+package team1.housework.group.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.GroupMember;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+	List<GroupMember> findByGroupId(Long groupId);
+}

--- a/src/main/java/team1/housework/group/repository/GroupMemberRepository.java
+++ b/src/main/java/team1/housework/group/repository/GroupMemberRepository.java
@@ -1,6 +1,7 @@
 package team1.housework.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,5 @@ import team1.housework.group.entity.GroupMember;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
 	List<GroupMember> findByGroupId(Long groupId);
+	Optional<GroupMember> findFirstByMemberId(Long memberId);
 }

--- a/src/main/java/team1/housework/group/repository/GroupRepository.java
+++ b/src/main/java/team1/housework/group/repository/GroupRepository.java
@@ -1,0 +1,12 @@
+package team1.housework.group.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+	Optional<Group> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/team1/housework/group/repository/HouseWorkRepository.java
+++ b/src/main/java/team1/housework/group/repository/HouseWorkRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.HouseWork;
+
+public interface HouseWorkRepository extends JpaRepository<HouseWork, Long> {
+}

--- a/src/main/java/team1/housework/group/repository/HouseWorkTagRepository.java
+++ b/src/main/java/team1/housework/group/repository/HouseWorkTagRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.HouseWorkTag;
+
+public interface HouseWorkTagRepository extends JpaRepository<HouseWorkTag, Long> {
+}

--- a/src/main/java/team1/housework/group/repository/PlaceRepository.java
+++ b/src/main/java/team1/housework/group/repository/PlaceRepository.java
@@ -1,0 +1,12 @@
+package team1.housework.group.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.Place;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+	List<Place> findByGroupId(Long groupId);
+}

--- a/src/main/java/team1/housework/group/repository/TagRepository.java
+++ b/src/main/java/team1/housework/group/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package team1.housework.group.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.group.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+	List<Tag> findByGroupId(Long groupId);
+}

--- a/src/main/java/team1/housework/group/service/GroupService.java
+++ b/src/main/java/team1/housework/group/service/GroupService.java
@@ -1,0 +1,126 @@
+package team1.housework.group.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.character.service.CharacterService;
+import team1.housework.group.entity.Group;
+import team1.housework.group.entity.GroupMember;
+import team1.housework.group.entity.Place;
+import team1.housework.group.entity.Tag;
+import team1.housework.group.repository.GroupMemberRepository;
+import team1.housework.group.repository.GroupRepository;
+import team1.housework.group.repository.PlaceRepository;
+import team1.housework.group.repository.TagRepository;
+import team1.housework.group.service.dto.EnterRequest;
+import team1.housework.group.service.dto.EnterResponse;
+import team1.housework.group.service.dto.GroupRequest;
+import team1.housework.group.service.dto.GroupResponse;
+import team1.housework.group.service.dto.MemberResponse;
+import team1.housework.group.service.dto.PlaceResponse;
+import team1.housework.group.service.dto.TagResponse;
+import team1.housework.group.service.generator.InviteCodeGenerator;
+import team1.housework.member.entity.Member;
+import team1.housework.member.service.MemberService;
+import team1.housework.preset.service.PresetService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GroupService {
+
+	private final GroupRepository groupRepository;
+	private final PlaceRepository placeRepository;
+	private final TagRepository tagRepository;
+	private final GroupMemberRepository groupMemberRepository;
+
+	private final InviteCodeGenerator inviteCodeGenerator;
+
+	private final CharacterService characterService;
+	private final PresetService presetService;
+	private final MemberService memberService;
+
+	@Transactional
+	public GroupResponse save(Member member, GroupRequest groupRequest) {
+		Boolean existsByCharacterId = characterService.existsById(groupRequest.characterId());
+		if (!existsByCharacterId) {
+			throw new NoSuchElementException("Character does not exist");
+		}
+		//초대코드 생성
+		String inviteCode = inviteCodeGenerator.generateInviteCode();
+		//그룹생성
+		Group group = new Group(groupRequest.characterId(), inviteCode);
+		groupRepository.save(group);
+		//요청자 그룹 멤버에 추가
+		GroupMember groupMember = new GroupMember(group, member.getId());
+		groupMemberRepository.save(groupMember);
+		//장소, 태그 프리셋 복사해 생성
+		List<Place> places = presetService.getAllPlaces()
+			.stream()
+			.map(it -> new Place(it.getName(), group))
+			.toList();
+		placeRepository.saveAll(places);
+
+		List<Tag> tags = presetService.getAllTags()
+			.stream()
+			.map(it -> new Tag(it.getName(), group))
+			.toList();
+		tagRepository.saveAll(tags);
+
+		return new GroupResponse(group.getId(), group.getInviteCode());
+	}
+
+	@Transactional
+	public EnterResponse enter(Member member, EnterRequest enterRequest) {
+		Group group = groupRepository.findByInviteCode(enterRequest.inviteCode())
+			.orElseThrow(() -> new NoSuchElementException("Invite code does not exist"));
+		//멤버추가
+		GroupMember groupMember = new GroupMember(group, member.getId());
+		groupMemberRepository.save(groupMember);
+		return new EnterResponse(group.getId());
+	}
+
+	public List<PlaceResponse> getPlaces(Long groupId) {
+		validateGroupExists(groupId);
+		return placeRepository.findByGroupId(groupId)
+			.stream()
+			.map(it -> new PlaceResponse(it.getId(), it.getName()))
+			.toList();
+	}
+
+	public List<TagResponse> getTags(Long groupId) {
+		validateGroupExists(groupId);
+		return tagRepository.findByGroupId(groupId)
+			.stream()
+			.map(it -> new TagResponse(it.getId(), it.getName()))
+			.toList();
+	}
+
+	public List<MemberResponse> getMembers(Long groupId) {
+		validateGroupExists(groupId);
+		return groupMemberRepository.findByGroupId(groupId)
+			.stream()
+			.map(it -> {
+				Member member = memberService.findById(it.getId());
+				return new MemberResponse(
+					member.getId(),
+					member.getName() == null ? null : member.getName(),
+					member.getProfileImageUrl() == null ? null : member.getProfileImageUrl()
+				);
+			})
+			.toList();
+
+	}
+
+	private void validateGroupExists(Long groupId) {
+		boolean exists = groupRepository.existsById(groupId);
+		if (!exists) {
+			throw new NoSuchElementException("Group does not exist");
+		}
+	}
+
+}

--- a/src/main/java/team1/housework/group/service/dto/EnterRequest.java
+++ b/src/main/java/team1/housework/group/service/dto/EnterRequest.java
@@ -1,0 +1,6 @@
+package team1.housework.group.service.dto;
+
+public record EnterRequest(
+	String inviteCode
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/EnterResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/EnterResponse.java
@@ -1,0 +1,6 @@
+package team1.housework.group.service.dto;
+
+public record EnterResponse(
+	Long groupId
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/GroupRequest.java
+++ b/src/main/java/team1/housework/group/service/dto/GroupRequest.java
@@ -1,0 +1,6 @@
+package team1.housework.group.service.dto;
+
+public record GroupRequest(
+	Long characterId
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/GroupResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/GroupResponse.java
@@ -1,0 +1,7 @@
+package team1.housework.group.service.dto;
+
+public record GroupResponse(
+	Long groupId,
+	String inviteCode
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/HouseWorkResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/HouseWorkResponse.java
@@ -1,0 +1,6 @@
+package team1.housework.group.service.dto;
+
+public record HouseWorkResponse(
+	Long houseWorkId
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/HouseWorkSaveRequest.java
+++ b/src/main/java/team1/housework/group/service/dto/HouseWorkSaveRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record HouseWorkSaveRequest(
 	String houseWorkName,
 	Long placeId,
+	List<Long> tags,
 	LocalDate startDate,
 	LocalDate dueDate,
 	String routinePolicy,

--- a/src/main/java/team1/housework/group/service/dto/HouseWorkSaveRequest.java
+++ b/src/main/java/team1/housework/group/service/dto/HouseWorkSaveRequest.java
@@ -1,0 +1,15 @@
+package team1.housework.group.service.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record HouseWorkSaveRequest(
+	String houseWorkName,
+	Long placeId,
+	LocalDate startDate,
+	LocalDate dueDate,
+	String routinePolicy,
+	List<String> dayOfWeek,
+	boolean isNotified
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/MemberResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/MemberResponse.java
@@ -1,0 +1,8 @@
+package team1.housework.group.service.dto;
+
+public record MemberResponse(
+	Long memberId,
+	String name,
+	String profileImageUrl
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/MyGroupResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/MyGroupResponse.java
@@ -1,0 +1,6 @@
+package team1.housework.group.service.dto;
+
+public record MyGroupResponse(
+	Long groupId
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/PlaceResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/PlaceResponse.java
@@ -1,0 +1,7 @@
+package team1.housework.group.service.dto;
+
+public record PlaceResponse(
+	Long placeId,
+	String name
+) {
+}

--- a/src/main/java/team1/housework/group/service/dto/TagResponse.java
+++ b/src/main/java/team1/housework/group/service/dto/TagResponse.java
@@ -1,0 +1,7 @@
+package team1.housework.group.service.dto;
+
+public record TagResponse(
+	Long tagId,
+	String name
+) {
+}

--- a/src/main/java/team1/housework/group/service/generator/InviteCodeGenerator.java
+++ b/src/main/java/team1/housework/group/service/generator/InviteCodeGenerator.java
@@ -1,0 +1,7 @@
+package team1.housework.group.service.generator;
+
+public interface InviteCodeGenerator {
+
+	String generateInviteCode();
+
+}

--- a/src/main/java/team1/housework/group/service/generator/RandomInviteCodeGenerator.java
+++ b/src/main/java/team1/housework/group/service/generator/RandomInviteCodeGenerator.java
@@ -1,0 +1,22 @@
+package team1.housework.group.service.generator;
+
+import java.security.SecureRandom;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomInviteCodeGenerator implements InviteCodeGenerator {
+
+	private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789"; // 0 제외
+	private static final int CODE_LENGTH = 6;
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	public String generateInviteCode() {
+		StringBuilder code = new StringBuilder(CODE_LENGTH);
+		for (int i = 0; i < CODE_LENGTH; i++) {
+			int index = RANDOM.nextInt(CHAR_POOL.length());
+			code.append(CHAR_POOL.charAt(index));
+		}
+		return code.toString();
+	}
+}

--- a/src/main/java/team1/housework/group/service/policy/DayOfWeekPolicy.java
+++ b/src/main/java/team1/housework/group/service/policy/DayOfWeekPolicy.java
@@ -1,0 +1,23 @@
+package team1.housework.group.service.policy;
+
+import java.time.DayOfWeek;
+
+public enum DayOfWeekPolicy {
+	MONDAY(DayOfWeek.MONDAY),
+	TUESDAY(DayOfWeek.TUESDAY),
+	WEDNESDAY(DayOfWeek.WEDNESDAY),
+	THURSDAY(DayOfWeek.THURSDAY),
+	FRIDAY(DayOfWeek.FRIDAY),
+	SATURDAY(DayOfWeek.SATURDAY),
+	SUNDAY(DayOfWeek.SUNDAY);
+
+	private final DayOfWeek dayOfWeek;
+
+	DayOfWeekPolicy(DayOfWeek dayOfWeek) {
+		this.dayOfWeek = dayOfWeek;
+	}
+
+	public DayOfWeek toJavaDayOfWeek() {
+		return dayOfWeek;
+	}
+}

--- a/src/main/java/team1/housework/group/service/policy/RoutinePolicy.java
+++ b/src/main/java/team1/housework/group/service/policy/RoutinePolicy.java
@@ -1,0 +1,64 @@
+package team1.housework.group.service.policy;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public enum RoutinePolicy {
+	NONE {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			// NONE → startDate 1건만 등록 (요일 무시)
+			return current.equals(startDate);
+		}
+	},
+	EVERY_DAY {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			// targetDays 비어있으면 저장 안 함
+			return !targetDays.isEmpty() && targetDays.contains(current.getDayOfWeek());
+		}
+	},
+	EVERY_WEEK {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			return isTargetDay(current, targetDays) &&
+				ChronoUnit.WEEKS.between(startDate, current) % 1 == 0;
+		}
+	},
+	BI_WEEK {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			return isTargetDay(current, targetDays) &&
+				ChronoUnit.WEEKS.between(startDate, current) % 2 == 0;
+		}
+	},
+	EVERY_MONTH {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			return isTargetDay(current, targetDays) &&
+				ChronoUnit.MONTHS.between(startDate, current) % 1 == 0;
+		}
+	},
+	THREE_MONTH {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			return isTargetDay(current, targetDays) &&
+				ChronoUnit.MONTHS.between(startDate, current) % 3 == 0;
+		}
+	},
+	SIX_MONTH {
+		@Override
+		public boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays) {
+			return isTargetDay(current, targetDays) &&
+				ChronoUnit.MONTHS.between(startDate, current) % 6 == 0;
+		}
+	};
+
+	public abstract boolean shouldAdd(LocalDate startDate, LocalDate current, List<DayOfWeek> targetDays);
+
+	protected boolean isTargetDay(LocalDate current, List<DayOfWeek> targetDays) {
+		return !targetDays.isEmpty() && targetDays.contains(current.getDayOfWeek());
+	}
+}

--- a/src/main/java/team1/housework/member/entity/Member.java
+++ b/src/main/java/team1/housework/member/entity/Member.java
@@ -16,7 +16,7 @@ public class Member {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String loginId;
+	private String code;
 
 	private String name;
 

--- a/src/main/java/team1/housework/member/entity/Member.java
+++ b/src/main/java/team1/housework/member/entity/Member.java
@@ -1,0 +1,24 @@
+package team1.housework.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String loginId;
+
+	private String name;
+
+	private String profileImageUrl;
+}

--- a/src/main/java/team1/housework/member/repository/MemberRepository.java
+++ b/src/main/java/team1/housework/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/team1/housework/member/service/MemberService.java
+++ b/src/main/java/team1/housework/member/service/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import team1.housework.group.service.dto.MyGroupResponse;
 import team1.housework.member.entity.Member;
 import team1.housework.member.repository.MemberRepository;
 
@@ -21,4 +22,7 @@ public class MemberService {
 			.orElseThrow(() -> new NoSuchElementException("Member not found"));
 	}
 
+	public MyGroupResponse getMyGroup(Member member) {
+		return null;
+	}
 }

--- a/src/main/java/team1/housework/member/service/MemberService.java
+++ b/src/main/java/team1/housework/member/service/MemberService.java
@@ -1,0 +1,24 @@
+package team1.housework.member.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.member.entity.Member;
+import team1.housework.member.repository.MemberRepository;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public Member findById(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new NoSuchElementException("Member not found"));
+	}
+
+}

--- a/src/main/java/team1/housework/preset/controller/PresetController.java
+++ b/src/main/java/team1/housework/preset/controller/PresetController.java
@@ -1,0 +1,24 @@
+package team1.housework.preset.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.preset.service.PresetService;
+import team1.housework.preset.service.dto.PresetHouseWorkResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/preset")
+public class PresetController {
+
+	private final PresetService presetService;
+
+	@GetMapping("/house-work")
+	public List<PresetHouseWorkResponse> getPresetHouseWorks() {
+		return presetService.getPresetHouseWorks();
+	}
+}

--- a/src/main/java/team1/housework/preset/entity/PresetHouseWork.java
+++ b/src/main/java/team1/housework/preset/entity/PresetHouseWork.java
@@ -1,0 +1,27 @@
+package team1.housework.preset.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PresetHouseWork {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "preset_house_work_category_id")
+	private PresetHouseWorkCategory presetHouseWorkCategory;
+
+	private String name;
+
+}

--- a/src/main/java/team1/housework/preset/entity/PresetHouseWorkCategory.java
+++ b/src/main/java/team1/housework/preset/entity/PresetHouseWorkCategory.java
@@ -1,0 +1,20 @@
+package team1.housework.preset.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PresetHouseWorkCategory {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+}

--- a/src/main/java/team1/housework/preset/entity/PresetPlace.java
+++ b/src/main/java/team1/housework/preset/entity/PresetPlace.java
@@ -1,0 +1,22 @@
+package team1.housework.preset.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PresetPlace {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+}

--- a/src/main/java/team1/housework/preset/entity/PresetTag.java
+++ b/src/main/java/team1/housework/preset/entity/PresetTag.java
@@ -1,0 +1,21 @@
+package team1.housework.preset.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PresetTag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+}

--- a/src/main/java/team1/housework/preset/repository/PresetHouseWorkCategoryRepository.java
+++ b/src/main/java/team1/housework/preset/repository/PresetHouseWorkCategoryRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.preset.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.preset.entity.PresetHouseWorkCategory;
+
+public interface PresetHouseWorkCategoryRepository extends JpaRepository<PresetHouseWorkCategory, Long> {
+}

--- a/src/main/java/team1/housework/preset/repository/PresetHouseWorkRepository.java
+++ b/src/main/java/team1/housework/preset/repository/PresetHouseWorkRepository.java
@@ -1,0 +1,12 @@
+package team1.housework.preset.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.preset.entity.PresetHouseWork;
+
+public interface PresetHouseWorkRepository extends JpaRepository<PresetHouseWork, Long> {
+
+	List<PresetHouseWork> findByPresetHouseWorkCategoryId(Long presetHouseWorkCategoryId);
+}

--- a/src/main/java/team1/housework/preset/repository/PresetPlaceRepository.java
+++ b/src/main/java/team1/housework/preset/repository/PresetPlaceRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.preset.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.preset.entity.PresetPlace;
+
+public interface PresetPlaceRepository extends JpaRepository<PresetPlace, Long> {
+}

--- a/src/main/java/team1/housework/preset/repository/PresetTagRepository.java
+++ b/src/main/java/team1/housework/preset/repository/PresetTagRepository.java
@@ -1,0 +1,8 @@
+package team1.housework.preset.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team1.housework.preset.entity.PresetTag;
+
+public interface PresetTagRepository extends JpaRepository<PresetTag, Long> {
+}

--- a/src/main/java/team1/housework/preset/service/PresetService.java
+++ b/src/main/java/team1/housework/preset/service/PresetService.java
@@ -1,0 +1,52 @@
+package team1.housework.preset.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team1.housework.preset.entity.PresetHouseWorkCategory;
+import team1.housework.preset.entity.PresetPlace;
+import team1.housework.preset.entity.PresetTag;
+import team1.housework.preset.repository.PresetHouseWorkCategoryRepository;
+import team1.housework.preset.repository.PresetHouseWorkRepository;
+import team1.housework.preset.repository.PresetPlaceRepository;
+import team1.housework.preset.repository.PresetTagRepository;
+import team1.housework.preset.service.dto.PresetHouseWorkResponse;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PresetService {
+
+	private final PresetPlaceRepository presetPlaceRepository;
+	private final PresetTagRepository presetTagRepository;
+	private final PresetHouseWorkRepository presetHouseWorkRepository;
+	private final PresetHouseWorkCategoryRepository presetHouseWorkCategoryRepository;
+
+	public List<PresetPlace> getAllPlaces() {
+		return presetPlaceRepository.findAll();
+	}
+
+	public List<PresetTag> getAllTags() {
+		return presetTagRepository.findAll();
+	}
+
+	public List<PresetHouseWorkResponse> getPresetHouseWorks() {
+		List<PresetHouseWorkCategory> categories = presetHouseWorkCategoryRepository.findAll();
+		List<PresetHouseWorkResponse> results = new ArrayList<>();
+		for (PresetHouseWorkCategory category : categories) {
+			List<PresetHouseWorkResponse.HouseWork> houseWorks = presetHouseWorkRepository.findByPresetHouseWorkCategoryId(
+					category.getId())
+				.stream()
+				.map(it -> new PresetHouseWorkResponse.HouseWork(it.getId(), it.getName()))
+				.toList();
+			results.add(new PresetHouseWorkResponse(
+				category.getId(), category.getName(), houseWorks
+			));
+		}
+		return results;
+	}
+}

--- a/src/main/java/team1/housework/preset/service/dto/PresetHouseWorkResponse.java
+++ b/src/main/java/team1/housework/preset/service/dto/PresetHouseWorkResponse.java
@@ -1,0 +1,14 @@
+package team1.housework.preset.service.dto;
+
+import java.util.List;
+
+public record PresetHouseWorkResponse(
+	Long houseWorkCatId,
+	String catName,
+	List<HouseWork> houseWorks
+) {
+	public record HouseWork(
+		Long houseWorkId,
+		String name
+	) {}
+}


### PR DESCRIPTION
## 📄 설명

개발 API 목록
- 그룹 생성
- 그룹 입장
- 그룹 장소 목록 조회
- 그룹 태그 목록 조회
- 그룹 멤버 조회
- 프리셋 집안일 목록 조회
- 집안일 일정 추가
- 사용자 그룹 조회

## ✔️ 작업한 내용

@Auth 라는 ArgumentResolver를 사용해서 accessToken을 파싱해 멤버 객체를 컨트롤러에 바인딩할 생각인데
지금 회원가입, 로그인 과정이 구현이 안 돼 있어서 @Auth  api 테스트가 불가능해요.
다음 PR에 로그인/회원가입 바로 구현해서 올릴건데 
일단 다른 파트 API 로직 개발도 중요하니 이 부분 먼저 올리겠습니다!

## 🔒 이슈 닫기

- resolved: #12 