### PR TITLE
S3 이미지 업로드 및 삭제 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+uploads

--- a/build.gradle
+++ b/build.gradle
@@ -1,79 +1,80 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'team1'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 springBoot {
-	mainClass = 'team1.housework.HouseworkApplication'
+    mainClass = 'team1.housework.HouseworkApplication'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springAiVersion', "1.0.0")
+    set('springAiVersion', "1.0.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
 
-	// Querydsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'com.h2database:h2'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // 기존 jar 생성을 비활성화 (bootJar만 생성)
 tasks.named('jar') {
-	enabled = false
+    enabled = false
 }
 
 // bootJar 이름을 고정
 tasks.named('bootJar') {
-	archiveFileName = 'app.jar'
+    archiveFileName = 'app.jar'
 }

--- a/src/main/java/team1/housework/s3/service/S3Service.java
+++ b/src/main/java/team1/housework/s3/service/S3Service.java
@@ -1,0 +1,63 @@
+package team1.housework.s3.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final S3Template s3Template;
+
+	@Value("${spring.cloud.aws.s3.bucket}")
+	private String bucketName;
+
+	public String uploadImageAndGetUrl(MultipartFile image) {
+		String key = UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+		URL url;
+		try (InputStream inputStream = image.getInputStream()) {
+			url = s3Template.upload(
+				bucketName,
+				key,
+				inputStream,
+				ObjectMetadata.builder()
+					.contentType(image.getContentType())
+					.build()
+			).getURL();
+		} catch (IOException e) {
+			throw new RuntimeException("S3 Error", e);
+		}
+		return url.toString();
+	}
+
+	public void deleteImage(String url) {
+		String key;
+		try {
+			key = new URI(url)
+				.toURL()
+				.getPath()
+				.substring(1);
+		} catch (MalformedURLException | URISyntaxException e) {
+			throw new RuntimeException("S3 Error", e);
+		}
+		String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8);
+
+		s3Template.deleteObject(bucketName, decodedKey);
+	}
+}

--- a/src/main/java/team1/housework/storage/StorageUtils.java
+++ b/src/main/java/team1/housework/storage/StorageUtils.java
@@ -1,0 +1,15 @@
+package team1.housework.storage;
+
+import java.util.UUID;
+
+public class StorageUtils {
+
+	public static String getFileName(String originalFilename) {
+		String extension = "";
+		int lastDotIndex = originalFilename.lastIndexOf('.');
+		if (lastDotIndex != -1) {
+			extension = originalFilename.substring(lastDotIndex);
+		}
+		return UUID.randomUUID() + extension;
+	}
+}

--- a/src/main/java/team1/housework/storage/StorageUtils.java
+++ b/src/main/java/team1/housework/storage/StorageUtils.java
@@ -2,9 +2,29 @@ package team1.housework.storage;
 
 import java.util.UUID;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public class StorageUtils {
 
+	public static void verifyImage(MultipartFile image) {
+		if (image == null || image.isEmpty()) {
+			throw new IllegalArgumentException("Image file is empty.");
+		}
+	}
+
+	public static String verifyAndGetContentType(MultipartFile image) {
+		String contentType = image.getContentType();
+		if (contentType == null || !contentType.startsWith("image/")) {
+			throw new IllegalArgumentException("Only image content types are allowed.");
+		}
+		return contentType;
+	}
+
 	public static String getFileName(String originalFilename) {
+		if (originalFilename == null || originalFilename.isBlank()) {
+			throw new IllegalArgumentException("File name is missing.");
+		}
+
 		String extension = "";
 		int lastDotIndex = originalFilename.lastIndexOf('.');
 		if (lastDotIndex != -1) {

--- a/src/main/java/team1/housework/storage/service/LocalStorageService.java
+++ b/src/main/java/team1/housework/storage/service/LocalStorageService.java
@@ -1,0 +1,57 @@
+package team1.housework.storage.service;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import team1.housework.storage.StorageUtils;
+
+@Service
+@Profile("!prod")
+public class LocalStorageService implements StorageService {
+
+	@Value("${file.upload.directory:uploads}")
+	private String uploadDirectory;
+
+	@Override
+	public String uploadImageAndGetUrl(MultipartFile image) {
+		// 절대 경로로 변환
+		File directory = new File(uploadDirectory).getAbsoluteFile();
+		if (!directory.exists()) {
+			boolean created = directory.mkdirs();
+			if (!created) {
+				throw new RuntimeException("Failed to create directory: " + directory.getAbsolutePath());
+			}
+		}
+
+		// 파일명 생성
+		String originalFilename = image.getOriginalFilename();
+		if (originalFilename == null) {
+			throw new IllegalArgumentException("File name is missing.");
+		}
+
+		String fileName = StorageUtils.getFileName(originalFilename);
+		// 파일 저장
+		try {
+			File file = new File(directory, fileName);
+			image.transferTo(file);
+
+			return "https://fake/" + fileName;
+		} catch (IOException e) {
+			throw new RuntimeException("File upload failed", e);
+		}
+	}
+
+	@Override
+	public void deleteImage(String url) {
+		String fileName = url.substring(url.lastIndexOf('/') + 1);
+		File file = new File(uploadDirectory, fileName);
+		if (file.exists()) {
+			file.delete();
+		}
+	}
+}

--- a/src/main/java/team1/housework/storage/service/LocalStorageService.java
+++ b/src/main/java/team1/housework/storage/service/LocalStorageService.java
@@ -19,6 +19,8 @@ public class LocalStorageService implements StorageService {
 
 	@Override
 	public String uploadImageAndGetUrl(MultipartFile image) {
+		StorageUtils.verifyImage(image);
+
 		// 절대 경로로 변환
 		File directory = new File(uploadDirectory).getAbsoluteFile();
 		if (!directory.exists()) {
@@ -29,12 +31,8 @@ public class LocalStorageService implements StorageService {
 		}
 
 		// 파일명 생성
-		String originalFilename = image.getOriginalFilename();
-		if (originalFilename == null) {
-			throw new IllegalArgumentException("File name is missing.");
-		}
+		String fileName = StorageUtils.getFileName(image.getOriginalFilename());
 
-		String fileName = StorageUtils.getFileName(originalFilename);
 		// 파일 저장
 		try {
 			File file = new File(directory, fileName);

--- a/src/main/java/team1/housework/storage/service/S3StorageService.java
+++ b/src/main/java/team1/housework/storage/service/S3StorageService.java
@@ -1,4 +1,4 @@
-package team1.housework.s3.service;
+package team1.housework.storage.service;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -6,37 +6,35 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
+import team1.housework.storage.StorageUtils;
 
 @Service
+@Profile("prod")
 @RequiredArgsConstructor
-public class S3Service {
+public class S3StorageService implements StorageService {
 
 	private final S3Template s3Template;
 
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
 
+	@Override
 	public String uploadImageAndGetUrl(MultipartFile image) {
 		String originalFilename = image.getOriginalFilename();
 		if (originalFilename == null) {
 			throw new IllegalArgumentException("File name is missing.");
 		}
 
-		String extension = "";
-		int lastDotIndex = originalFilename.lastIndexOf('.');
-		if (lastDotIndex != -1) {
-			extension = originalFilename.substring(lastDotIndex);
-		}
-		String key = UUID.randomUUID() + extension;
+		String key = StorageUtils.getFileName(originalFilename);
 
 		URL url;
 		try (InputStream inputStream = image.getInputStream()) {
@@ -55,6 +53,7 @@ public class S3Service {
 		return url.toString();
 	}
 
+	@Override
 	public void deleteImage(String url) {
 		String key;
 		try {

--- a/src/main/java/team1/housework/storage/service/S3StorageService.java
+++ b/src/main/java/team1/housework/storage/service/S3StorageService.java
@@ -29,12 +29,10 @@ public class S3StorageService implements StorageService {
 
 	@Override
 	public String uploadImageAndGetUrl(MultipartFile image) {
-		String originalFilename = image.getOriginalFilename();
-		if (originalFilename == null) {
-			throw new IllegalArgumentException("File name is missing.");
-		}
+		StorageUtils.verifyImage(image);
+		String contentType = StorageUtils.verifyAndGetContentType(image);
 
-		String key = StorageUtils.getFileName(originalFilename);
+		String key = StorageUtils.getFileName(image.getOriginalFilename());
 
 		URL url;
 		try (InputStream inputStream = image.getInputStream()) {
@@ -43,7 +41,7 @@ public class S3StorageService implements StorageService {
 				key,
 				inputStream,
 				ObjectMetadata.builder()
-					.contentType(image.getContentType())
+					.contentType(contentType)
 					.build()
 			).getURL();
 		} catch (IOException e) {

--- a/src/main/java/team1/housework/storage/service/StorageService.java
+++ b/src/main/java/team1/housework/storage/service/StorageService.java
@@ -1,0 +1,10 @@
+package team1.housework.storage.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+	String uploadImageAndGetUrl(MultipartFile image);
+
+	void deleteImage(String url);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,3 +4,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  cloud:
+    aws:
+      credentials:
+        access-key: ${S3_ACCESS_KEY}
+        secret-key: ${S3_SECRET_KEY}
+      region:
+        static: ${S3_REGION}
+      s3:
+        bucket: ${S3_BUCKET_NAME}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-spring.application.name=housework
-
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.h2.console.enabled=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,12 @@ spring:
   h2:
     console:
       enabled: true
+
+  cloud:
+    aws:
+      s3:
+        enabled: false
+
+file:
+  upload:
+    directory: ./uploads

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: housework
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
## 📄 설명

- S3Template 사용을 위한 의존성 및 설정 추가
- 이미지 업로드 및 삭제 기능 구현
- 로컬에서는 S3를 사용하지 않도록 환경 분리

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- S3Service를 구현했고 해당 클래스 내부에 업로드, 삭제 메서드를 구현했습니다.
  - uploadImageAndGetUrl(MultipartFile image)
  - deleteImage(String url)
- 설정 파일에 필요한 변수들은 EC2안에 환경 변수로 저장했습니다.
- 로컬 설정 파일(application.yml)에서는 S3를 사용하지 않도록 하고 이미지가 저장될 경로를 변수로 만들었습니다.
- S3StorageService는 `@Profile("prod")`, LocalStorageService는 `@Profile("!prod")`로 설정했습니다.

## 🔒 이슈 닫기

- resolved: #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image upload capability with automatic unique filenames.
  * In production, images are stored in AWS S3 with shareable URLs; in non-production, files are saved locally with generated URLs.

* **Chores**
  * Introduced environment-based cloud configuration (keys, region, bucket).
  * Consolidated app settings into YAML; default local upload directory added and S3 disabled by default.
  * Updated ignore rules to exclude the local uploads folder from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->