### PR TITLE
feat: 카카오 로그인 및 jwt 액세스토큰 발급 & @Auth에 Member 객체 바인딩

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/team1/allo/auth/annotation/Auth.java
+++ b/src/main/java/team1/allo/auth/annotation/Auth.java
@@ -1,0 +1,13 @@
+package team1.allo.auth.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Auth {
+}

--- a/src/main/java/team1/allo/auth/aop/Auth.java
+++ b/src/main/java/team1/allo/auth/aop/Auth.java
@@ -1,4 +1,0 @@
-package team1.allo.auth.aop;
-
-public @interface Auth {
-}

--- a/src/main/java/team1/allo/auth/argumentresolver/AuthArgumentResolver.java
+++ b/src/main/java/team1/allo/auth/argumentresolver/AuthArgumentResolver.java
@@ -1,0 +1,41 @@
+package team1.allo.auth.argumentresolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import team1.allo.auth.annotation.Auth;
+import team1.allo.auth.jwt.JwtProvider;
+import team1.allo.member.entity.Member;
+import team1.allo.member.repository.MemberRepository;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(Auth.class)
+			&& parameter.getParameterType().equals(Member.class);
+	}
+
+	@Override
+	public Mono<Object> resolveArgument(MethodParameter parameter,
+		org.springframework.web.reactive.BindingContext bindingContext,
+		ServerWebExchange exchange) {
+		String authHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			return Mono.empty();
+		}
+		String token = authHeader.substring(7);
+		Long memberId = jwtProvider.parseMemberId(token);
+		return Mono.justOrEmpty(memberRepository.findById(memberId));
+	}
+}
+

--- a/src/main/java/team1/allo/auth/client/KakaoClient.java
+++ b/src/main/java/team1/allo/auth/client/KakaoClient.java
@@ -1,0 +1,25 @@
+package team1.allo.auth.client;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import team1.allo.auth.service.dto.KakaoUserResponse;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+	private final WebClient webClient = WebClient.builder()
+		.baseUrl("https://kapi.kakao.com")
+		.build();
+
+	public Mono<KakaoUserResponse> getUserInfo(String accessToken) {
+		return webClient.get()
+			.uri("/v2/user/me")
+			.header("Authorization", "Bearer " + accessToken)
+			.retrieve()
+			.bodyToMono(KakaoUserResponse.class);
+	}
+}

--- a/src/main/java/team1/allo/auth/controller/AuthController.java
+++ b/src/main/java/team1/allo/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package team1.allo.auth.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import team1.allo.auth.service.AuthService;
+import team1.allo.auth.service.dto.KakaoLoginRequest;
+import team1.allo.auth.service.dto.LoginResponse;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	private final AuthService authService;
+
+	@PostMapping("/login")
+	public LoginResponse login(@RequestBody KakaoLoginRequest request) {
+		return authService.login(request.accessToken());
+	}
+
+}

--- a/src/main/java/team1/allo/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team1/allo/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package team1.allo.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import team1.allo.auth.jwt.JwtProvider;
+import team1.allo.member.entity.Member;
+import team1.allo.member.repository.MemberRepository;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String authHeader = request.getHeader("Authorization");
+
+		if (authHeader != null && authHeader.startsWith("Bearer ")) {
+			String token = authHeader.substring(7);
+			try {
+				Long memberId = jwtProvider.parseMemberId(token);
+				Member member = memberRepository.findById(memberId).orElse(null);
+
+				if (member != null) {
+					UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(member, null, null);
+					authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+					SecurityContextHolder.getContext().setAuthentication(authentication);
+				}
+			} catch (Exception e) {
+				// JWT가 만료되었거나 유효하지 않은 경우 → 그냥 인증 없이 통과 (401은 SecurityConfig에서 처리됨)
+				SecurityContextHolder.clearContext();
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/team1/allo/auth/jwt/AppJwtProps.java
+++ b/src/main/java/team1/allo/auth/jwt/AppJwtProps.java
@@ -1,0 +1,6 @@
+package team1.allo.auth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public record AppJwtProps(String secret, long expirationMillis) {}

--- a/src/main/java/team1/allo/auth/jwt/JwtProvider.java
+++ b/src/main/java/team1/allo/auth/jwt/JwtProvider.java
@@ -1,0 +1,46 @@
+package team1.allo.auth.jwt;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+
+	private final SecretKey secretKey;
+	private final long expirationMillis;
+
+	public JwtProvider(AppJwtProps props) {
+		this.secretKey = Keys.hmacShaKeyFor(props.secret().getBytes());
+		this.expirationMillis = props.expirationMillis();
+	}
+
+	public String generateToken(Long memberId) {
+		Date now = new Date();
+		Date expiry = new Date(now.getTime() + expirationMillis);
+
+		return Jwts.builder()
+			.subject(String.valueOf(memberId))
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public Long parseMemberId(String token) {
+		return Long.valueOf(
+			Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload()
+				.getSubject()
+		);
+	}
+}
+

--- a/src/main/java/team1/allo/auth/service/AuthService.java
+++ b/src/main/java/team1/allo/auth/service/AuthService.java
@@ -1,0 +1,48 @@
+package team1.allo.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import team1.allo.auth.client.KakaoClient;
+import team1.allo.auth.jwt.JwtProvider;
+import team1.allo.auth.service.dto.KakaoUserResponse;
+import team1.allo.auth.service.dto.LoginResponse;
+import team1.allo.member.entity.Member;
+import team1.allo.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final KakaoClient kakaoClient;
+	private final MemberRepository memberRepository;
+	private final JwtProvider jwtProvider;
+
+	public LoginResponse login(String kakaoAccessToken) {
+		// WebClient 호출을 동기(blocking)으로 받음
+		KakaoUserResponse userInfo = kakaoClient.getUserInfo(kakaoAccessToken).block();
+
+		if (userInfo == null) {
+			throw new RuntimeException("카카오 사용자 정보를 불러오지 못했습니다.");
+		}
+
+		Long kakaoId = userInfo.id();
+		String nickname = userInfo.kakaoAccount().profile().nickname();
+		String code = "KAKAO_" + kakaoId;
+
+		Member member = memberRepository.findByCode(code)
+			.map(m -> m.toBuilder()
+				.name(nickname)
+				.build())
+			.orElse(Member.builder()
+				.code(code)
+				.name(nickname)
+				.build());
+
+		member = memberRepository.save(member);
+
+		String jwt = jwtProvider.generateToken(member.getId());
+		return new LoginResponse("Bearer " + jwt);
+	}
+}
+

--- a/src/main/java/team1/allo/auth/service/dto/KakaoLoginRequest.java
+++ b/src/main/java/team1/allo/auth/service/dto/KakaoLoginRequest.java
@@ -1,0 +1,4 @@
+package team1.allo.auth.service.dto;
+
+public record KakaoLoginRequest(String accessToken) {
+}

--- a/src/main/java/team1/allo/auth/service/dto/KakaoUserResponse.java
+++ b/src/main/java/team1/allo/auth/service/dto/KakaoUserResponse.java
@@ -1,0 +1,22 @@
+package team1.allo.auth.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserResponse(
+	Long id,
+	@JsonProperty("kakao_account")
+	KakaoAccount kakaoAccount
+) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record KakaoAccount(Profile profile) {
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Profile(
+		String nickname
+	) {
+
+	}
+}

--- a/src/main/java/team1/allo/auth/service/dto/LoginResponse.java
+++ b/src/main/java/team1/allo/auth/service/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package team1.allo.auth.service.dto;
+
+public record LoginResponse(String accessToken) {
+}

--- a/src/main/java/team1/allo/config/JwtConfig.java
+++ b/src/main/java/team1/allo/config/JwtConfig.java
@@ -1,0 +1,11 @@
+package team1.allo.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import team1.allo.auth.jwt.AppJwtProps;
+
+@Configuration
+@EnableConfigurationProperties(AppJwtProps.class)
+public class JwtConfig { }
+

--- a/src/main/java/team1/allo/config/SecurityConfig.java
+++ b/src/main/java/team1/allo/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package team1.allo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+import team1.allo.auth.filter.JwtAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/auth/login").permitAll()
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+}

--- a/src/main/java/team1/allo/emotioncard/controller/EmotionCardController.java
+++ b/src/main/java/team1/allo/emotioncard/controller/EmotionCardController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import team1.allo.auth.aop.Auth;
+import team1.allo.auth.annotation.Auth;
 import team1.allo.emotioncard.service.EmotionCardService;
 import team1.allo.emotioncard.service.dto.EmotionCardListRequest;
 import team1.allo.emotioncard.service.dto.EmotionCardListResponse;

--- a/src/main/java/team1/allo/group/controller/GroupController.java
+++ b/src/main/java/team1/allo/group/controller/GroupController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import team1.allo.auth.aop.Auth;
+import team1.allo.auth.annotation.Auth;
 import team1.allo.group.service.GroupService;
 import team1.allo.group.service.dto.EnterRequest;
 import team1.allo.group.service.dto.EnterResponse;

--- a/src/main/java/team1/allo/member/entity/Member.java
+++ b/src/main/java/team1/allo/member/entity/Member.java
@@ -5,12 +5,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class Member {
 
 	@Id

--- a/src/main/java/team1/allo/member/repository/MemberRepository.java
+++ b/src/main/java/team1/allo/member/repository/MemberRepository.java
@@ -1,8 +1,13 @@
 package team1.allo.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import team1.allo.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByCode(String code);
+
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,3 +13,8 @@ spring:
         static: ${S3_REGION}
       s3:
         bucket: ${S3_BUCKET_NAME}
+
+app:
+  jwt:
+    secret: ${JWT_SECRET_KEY}  # 최소 32byte 이상
+    expiration-millis: 3600000 # 1시간

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ spring:
 file:
   upload:
     directory: ./uploads
+
+app:
+  jwt:
+    secret: ${JWT_SECRET_KEY}  # 최소 32byte 이상
+    expiration-millis: 3600000 # 1시간


### PR DESCRIPTION
## 📄 설명

- 카카오와 JWT를 활용한 로그인 및 액세스토큰 발급

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- 

## 🔒 이슈 닫기

- resolved: #