### PR TITLE
Feature: 홈 화면 관련 API 구현

### DIFF
--- a/src/main/java/team1/allo/character/entity/Character.java
+++ b/src/main/java/team1/allo/character/entity/Character.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "house_work_ character")
+@Table(name = "house_work_character")
 public class Character {
 
 	@Id

--- a/src/main/java/team1/allo/group/controller/GroupController.java
+++ b/src/main/java/team1/allo/group/controller/GroupController.java
@@ -30,6 +30,7 @@ import team1.allo.housework.service.HouseWorkService;
 import team1.allo.housework.service.dto.HouseWorkActivitySummaryResponse;
 import team1.allo.housework.service.dto.HouseWorkCleanliness;
 import team1.allo.housework.service.dto.HouseWorkListByDateResponse;
+import team1.allo.housework.service.dto.HouseWorkListByPlaceResponse;
 import team1.allo.housework.service.dto.HouseWorkListRecentResponse;
 import team1.allo.housework.service.dto.HouseWorkMyCompleteStateResponse;
 import team1.allo.housework.service.dto.HouseWorkMyContributionResponse;
@@ -166,5 +167,13 @@ public class GroupController {
 	@GetMapping("/{groupId}/cleanliness")
 	public HouseWorkCleanliness getCleanliness(@PathVariable Long groupId) {
 		return houseWorkService.getCleanliness(groupId, LocalDate.now());
+	}
+
+	@GetMapping("/places/{placeId}/house-work")
+	public HouseWorkListByPlaceResponse getHouseWorksByPlace(
+		@Auth Member member,
+		@PathVariable Long placeId
+	) {
+		return houseWorkService.getHouseWorksByPlace(member.getId(), placeId, LocalDate.now());
 	}
 }

--- a/src/main/java/team1/allo/group/controller/GroupController.java
+++ b/src/main/java/team1/allo/group/controller/GroupController.java
@@ -28,6 +28,7 @@ import team1.allo.group.service.dto.TagResponse;
 import team1.allo.group.service.dto.TagSaveRequest;
 import team1.allo.housework.service.HouseWorkService;
 import team1.allo.housework.service.dto.HouseWorkActivitySummaryResponse;
+import team1.allo.housework.service.dto.HouseWorkCleanliness;
 import team1.allo.housework.service.dto.HouseWorkListByDateResponse;
 import team1.allo.housework.service.dto.HouseWorkListRecentResponse;
 import team1.allo.housework.service.dto.HouseWorkMyCompleteStateResponse;
@@ -160,5 +161,10 @@ public class GroupController {
 	@PostMapping("/{groupId}/places")
 	public void savePlace(@PathVariable Long groupId, @RequestBody PlaceSaveRequest request) {
 		groupService.savePlace(groupId, request);
+	}
+
+	@GetMapping("/{groupId}/cleanliness")
+	public HouseWorkCleanliness getCleanliness(@PathVariable Long groupId) {
+		return houseWorkService.getCleanliness(groupId, LocalDate.now());
 	}
 }

--- a/src/main/java/team1/allo/group/service/dto/MemberResponse.java
+++ b/src/main/java/team1/allo/group/service/dto/MemberResponse.java
@@ -1,8 +1,10 @@
 package team1.allo.group.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record MemberResponse(
 	Long memberId,
-	String memberNickName,
+	@JsonInclude(JsonInclude.Include.NON_NULL) String memberNickName,
 	String memberProfileImageUrl
 ) {
 }

--- a/src/main/java/team1/allo/housework/repository/housework/HouseWorkRepository.java
+++ b/src/main/java/team1/allo/housework/repository/housework/HouseWorkRepository.java
@@ -14,4 +14,6 @@ public interface HouseWorkRepository extends JpaRepository<HouseWork, Long>, Hou
 	long countHouseWorkByGroupIdAndTaskDate(Long groupId, LocalDate taskDate);
 
 	long countHouseWorkByGroupIdAndCompletedDate(Long groupId, LocalDate completedDate);
+
+	List<HouseWork> findByPlaceIdAndTaskDate(Long placeId, LocalDate taskDate);
 }

--- a/src/main/java/team1/allo/housework/repository/housework/HouseWorkRepository.java
+++ b/src/main/java/team1/allo/housework/repository/housework/HouseWorkRepository.java
@@ -10,4 +10,8 @@ import team1.allo.housework.entity.HouseWork;
 public interface HouseWorkRepository extends JpaRepository<HouseWork, Long>, HouseWorkCustomRepository {
 
 	List<HouseWork> findByGroupIdAndTaskDate(Long groupId, LocalDate taskDate);
+
+	long countHouseWorkByGroupIdAndTaskDate(Long groupId, LocalDate taskDate);
+
+	long countHouseWorkByGroupIdAndCompletedDate(Long groupId, LocalDate completedDate);
 }

--- a/src/main/java/team1/allo/housework/service/HouseWorkService.java
+++ b/src/main/java/team1/allo/housework/service/HouseWorkService.java
@@ -31,6 +31,7 @@ import team1.allo.housework.repository.housework.HouseWorkRepository;
 import team1.allo.housework.repository.houseworkmember.HouseWorkMemberRepository;
 import team1.allo.housework.repository.houseworktag.HouseWorkTagRepository;
 import team1.allo.housework.service.dto.HouseWorkActivitySummaryResponse;
+import team1.allo.housework.service.dto.HouseWorkCleanliness;
 import team1.allo.housework.service.dto.HouseWorkListByDateResponse;
 import team1.allo.housework.service.dto.HouseWorkListRecentResponse;
 import team1.allo.housework.service.dto.HouseWorkMyCompleteStateResponse;
@@ -361,6 +362,20 @@ public class HouseWorkService {
 		);
 	}
 
+	public HouseWorkCleanliness getCleanliness(Long groupId, LocalDate currentDate) {
+		// 오늘 기준 우리집 집안일 수
+		long total = houseWorkRepository.countHouseWorkByGroupIdAndTaskDate(groupId, currentDate);
+
+		// 오늘 기준 우리집 완료된 집안일 수
+		long completed = houseWorkRepository.countHouseWorkByGroupIdAndCompletedDate(groupId, currentDate);
+
+		int cleanliness = 0;
+		if (completed > 0) {
+			cleanliness = (int)Math.round((completed * 100.0) / total);
+		}
+		return new HouseWorkCleanliness(cleanliness);
+	}
+
 	// ===== Private Methods =====
 
 	private String getDayName(DayOfWeek dayOfWeek) {
@@ -377,6 +392,7 @@ public class HouseWorkService {
 		LocalDate monday = getMondayOfWeeksAgo(currentDate, weeksAgo);
 		return monday.plusDays(6);
 	}
+
 	public HouseWorkResponse getHouseWork(Long groupId, Long houseWorkId) {
 		HouseWork houseWork = houseWorkRepository.findById(houseWorkId)
 			.orElseThrow(() -> new NoSuchElementException("HouseWork does not exist"));

--- a/src/main/java/team1/allo/housework/service/HouseWorkService.java
+++ b/src/main/java/team1/allo/housework/service/HouseWorkService.java
@@ -169,6 +169,15 @@ public class HouseWorkService {
 						member.getProfileImageUrl()
 					);
 				})
+				.sorted((m1, m2) -> {
+					if (m1.memberId().equals(memberId)) {
+						return -1;
+					}
+					if (m2.memberId().equals(memberId)) {
+						return 1;
+					}
+					return 0;
+				})
 				.toList();
 
 			List<TagForHouseWorkListResponse> tagResponses = houseWorkTagMap.getOrDefault(houseWorkId, List.of())

--- a/src/main/java/team1/allo/housework/service/dto/HouseWorkByPlaceResponse.java
+++ b/src/main/java/team1/allo/housework/service/dto/HouseWorkByPlaceResponse.java
@@ -1,0 +1,12 @@
+package team1.allo.housework.service.dto;
+
+import java.util.List;
+
+import team1.allo.group.service.dto.MemberResponse;
+
+public record HouseWorkByPlaceResponse(
+	Long houseWorkId,
+	String houseWorkTitle,
+	List<MemberResponse> houseWorkMembers
+) {
+}

--- a/src/main/java/team1/allo/housework/service/dto/HouseWorkCleanliness.java
+++ b/src/main/java/team1/allo/housework/service/dto/HouseWorkCleanliness.java
@@ -1,0 +1,4 @@
+package team1.allo.housework.service.dto;
+
+public record HouseWorkCleanliness(int cleanliness) {
+}

--- a/src/main/java/team1/allo/housework/service/dto/HouseWorkListByPlaceResponse.java
+++ b/src/main/java/team1/allo/housework/service/dto/HouseWorkListByPlaceResponse.java
@@ -1,0 +1,9 @@
+package team1.allo.housework.service.dto;
+
+import java.util.List;
+
+public record HouseWorkListByPlaceResponse(
+	List<HouseWorkByPlaceResponse> myHouseWork,
+	List<HouseWorkByPlaceResponse> ourHouseWork
+) {
+}

--- a/src/main/java/team1/allo/housework/service/dto/HouseWorkResponse.java
+++ b/src/main/java/team1/allo/housework/service/dto/HouseWorkResponse.java
@@ -7,9 +7,9 @@ import team1.allo.group.service.dto.MemberResponse;
 
 public record HouseWorkResponse(
 	Long houseWorkId,
-	String houseworkTitle,
-	List<TagForHouseWorkListResponse> houseworkTag,
-	LocalDate houseworkDate,
-	List<MemberResponse> houseworkMembers
+	String houseWorkTitle,
+	List<TagForHouseWorkListResponse> houseWorkTag,
+	LocalDate houseWorkDate,
+	List<MemberResponse> houseWorkMembers
 ) {
 }

--- a/src/main/java/team1/allo/housework/service/dto/HouseWorkStatusByPeriodResponse.java
+++ b/src/main/java/team1/allo/housework/service/dto/HouseWorkStatusByPeriodResponse.java
@@ -4,6 +4,6 @@ import java.time.LocalDate;
 
 public record HouseWorkStatusByPeriodResponse(
 	LocalDate date,
-	boolean hasHousework
+	boolean hasHouseWork
 ) {
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,11 @@
-INSERT INTO groups (character_id, invite_code)
+INSERT INTO house_work_group (character_id, invite_code)
 VALUES (1, 'INVITE123'),
        (2, 'INVITE456'),
        (3, 'INVITE789'),
        (4, 'INVITE101'),
        (5, 'INVITE112');
 
-INSERT INTO character (name, image_url)
+INSERT INTO house_work_character (name, image_url)
 VALUES ('알로', 'https://fake.com/1.png'),
        ('깨끗이', 'https://fake.com/2.png'),
        ('코클린', 'https://fake.com/3.png'),
@@ -24,7 +24,7 @@ VALUES ('M001', '멤버1', 'https://fake.com/m1.png'),
        ('M009', '멤버9', 'https://fake.com/m9.png'),
        ('M010', '멤버10', 'https://fake.com/m10.png');
 
-INSERT INTO group_member (group_id, member_id)
+INSERT INTO group_member (house_work_group_id, member_id)
 VALUES (1, 1),
        (1, 2),
        (1, 3),
@@ -38,7 +38,7 @@ VALUES (1, 1),
        (4, 1),
        (4, 5);
 
-INSERT INTO place (name, group_id)
+INSERT INTO place (name, house_work_group_id)
 VALUES ('거실', 1),
        ('주방', 1),
        ('침실', 1),
@@ -49,7 +49,7 @@ VALUES ('거실', 1),
        ('화장실', 4),
        ('현관', 4);
 
-INSERT INTO tag (name, group_id)
+INSERT INTO tag (name, house_work_group_id)
 VALUES ('깨끗이', 1),
        ('빡빡', 1),
        ('쓱쓱', 2),
@@ -58,7 +58,7 @@ VALUES ('깨끗이', 1),
        ('크린토피아처럼', 3),
        ('매우열심히', 4);
 
-INSERT INTO house_work (name, place_id, group_id, task_date, notified, completed, completed_date)
+INSERT INTO house_work (name, place_id, house_work_group_id, task_date, notified, completed, completed_date)
 VALUES ('세탁기 돌리기', 4, 1, '2025-08-10', false, true, '2025-08-10'),
        ('바닥 청소', 1, 1, '2025-08-10', false, true, '2025-08-10'),
        ('쓰레기 버리기', 2, 1, '2025-08-10', true, false, null),


### PR DESCRIPTION
## 📄 설명

- 우리집 청결도 조회 (xx%)
- 특정 장소의 오늘의 집안일 조회
  - 로그인한 멤버가 집안일 멤버 목록에서 맨 앞으로 오도록 설정
- 기타 작업
  - Character 테이블명 수정
  - sql 파일에 수정된 테이블명 및 PK, FK명 반영
  - 응답 DTO 카멜케이스 통일 (housework => houseWork)

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- 캐릭터 상태 및 말풍선 대사 조회는 어차피 청결도에 따라 정해지는거라 셋을 하나의 API로 묶으면 될 거 같습니다. (보류)

## 🔒 이슈 닫기

- resolved: #31 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * View today’s cleanliness score for a group.
  * See today’s housework by place, split into “My” and “Our” lists.

* Improvements
  * Member lists now prioritize you first for easier recognition.
  * Enhanced privacy: member names are hidden; avatars are shown instead.
  * Consistent “HouseWork” terminology across responses and UI labels.

* Data/Content
  * Expanded default characters available for selection.

* Chores
  * Internal data naming aligned for consistency (no user action required).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->