### PR TITLE
나의 마음 카드 목록 조회 API 응답 데이터에 카드 타입 추가

### DIFF
--- a/src/main/java/team1/allo/emotioncard/repository/EmotionCardCustomRepository.java
+++ b/src/main/java/team1/allo/emotioncard/repository/EmotionCardCustomRepository.java
@@ -2,11 +2,11 @@ package team1.allo.emotioncard.repository;
 
 import java.util.List;
 
-import team1.allo.emotioncard.service.dto.EmotionCardListResponse;
+import team1.allo.emotioncard.service.dto.EmotionCardListDto;
 
 public interface EmotionCardCustomRepository {
 
-	List<EmotionCardListResponse> getAllWithCondition(Long memberId, String filter, String sorted);
+	List<EmotionCardListDto> getAllWithCondition(Long memberId, String filter, String sorted);
 
 	Long countEmotionCardSentByMember(Long memberId);
 

--- a/src/main/java/team1/allo/emotioncard/repository/EmotionCardCustomRepositoryImpl.java
+++ b/src/main/java/team1/allo/emotioncard/repository/EmotionCardCustomRepositoryImpl.java
@@ -12,7 +12,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
-import team1.allo.emotioncard.service.dto.EmotionCardListResponse;
+import team1.allo.emotioncard.service.dto.EmotionCardListDto;
 import team1.allo.member.entity.QMember;
 
 @RequiredArgsConstructor
@@ -21,13 +21,13 @@ public class EmotionCardCustomRepositoryImpl implements EmotionCardCustomReposit
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<EmotionCardListResponse> getAllWithCondition(Long memberId, String filter, String sorted) {
+	public List<EmotionCardListDto> getAllWithCondition(Long memberId, String filter, String sorted) {
 		QMember senderMember = new QMember("senderMember");
 		QMember receiverMember = new QMember("receiverMember");
 
 		return queryFactory.select(
 				Projections.constructor(
-					EmotionCardListResponse.class,
+					EmotionCardListDto.class,
 					emotionCard.id,
 					houseWork.name,
 					emotionCard.disappointment,
@@ -63,8 +63,8 @@ public class EmotionCardCustomRepositoryImpl implements EmotionCardCustomReposit
 
 	private BooleanExpression buildMemberFilter(Long memberId, String filter) {
 		return switch (filter) {
-			case "from" -> emotionCard.receiverId.eq(memberId);
-			case "to" -> emotionCard.senderId.eq(memberId);
+			case "received" -> emotionCard.receiverId.eq(memberId);
+			case "sent" -> emotionCard.senderId.eq(memberId);
 			default -> null;
 		};
 	}

--- a/src/main/java/team1/allo/emotioncard/service/dto/EmotionCardListDto.java
+++ b/src/main/java/team1/allo/emotioncard/service/dto/EmotionCardListDto.java
@@ -1,0 +1,13 @@
+package team1.allo.emotioncard.service.dto;
+
+import java.time.LocalDateTime;
+
+public record EmotionCardListDto(
+	Long emotionCardId,
+	String houseWorkName,
+	String content,
+	String senderNickName,
+	String receiverNickName,
+	LocalDateTime createdTime
+) {
+}

--- a/src/main/java/team1/allo/emotioncard/service/dto/EmotionCardListResponse.java
+++ b/src/main/java/team1/allo/emotioncard/service/dto/EmotionCardListResponse.java
@@ -8,6 +8,19 @@ public record EmotionCardListResponse(
 	String content,
 	String senderNickName,
 	String receiverNickName,
-	LocalDateTime createdTime
+	LocalDateTime createdTime,
+	String emotionType
 ) {
+
+	public static EmotionCardListResponse from(EmotionCardListDto dto, String newContent, String emotionType) {
+		return new EmotionCardListResponse(
+			dto.emotionCardId(),
+			dto.houseWorkName(),
+			newContent,
+			dto.senderNickName(),
+			dto.receiverNickName(),
+			dto.createdTime(),
+			emotionType
+		);
+	}
 }


### PR DESCRIPTION
## 📄 설명

- 나의 마음 카드 목록 조회 API 응답 데이터에 카드 타입 추가
  - both
  - thank
  - regretful

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- 

## 🔒 이슈 닫기

- resolved: #