### PR TITLE
예외 핸들러 추가

### DIFF
--- a/src/main/java/team1/allo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team1/allo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package team1.allo.exception;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import team1.allo.exception.dto.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler
+	public ErrorResponse exceptionHandler(RuntimeException e) {
+		return new ErrorResponse(e.getMessage());
+	}
+}

--- a/src/main/java/team1/allo/exception/dto/ErrorResponse.java
+++ b/src/main/java/team1/allo/exception/dto/ErrorResponse.java
@@ -1,0 +1,4 @@
+package team1.allo.exception.dto;
+
+public record ErrorResponse(String message) {
+}

--- a/src/main/java/team1/allo/group/repository/GroupMemberRepository.java
+++ b/src/main/java/team1/allo/group/repository/GroupMemberRepository.java
@@ -12,4 +12,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 	List<GroupMember> findByGroupId(Long groupId);
 
 	Optional<GroupMember> findFirstByMemberId(Long memberId);
+
+	boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/team1/allo/group/service/GroupService.java
+++ b/src/main/java/team1/allo/group/service/GroupService.java
@@ -76,10 +76,16 @@ public class GroupService {
 	public EnterResponse enter(Member member, EnterRequest enterRequest) {
 		Group group = groupRepository.findByInviteCode(enterRequest.inviteCode())
 			.orElseThrow(() -> new NoSuchElementException("Invite code does not exist"));
+
+		Long groupId = group.getId();
+		if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, member.getId())) {
+			throw new RuntimeException("Already a member of this group");
+		}
+
 		//멤버추가
 		GroupMember groupMember = new GroupMember(group, member.getId());
 		groupMemberRepository.save(groupMember);
-		return new EnterResponse(group.getId());
+		return new EnterResponse(groupId);
 	}
 
 	public List<PlaceResponse> getPlaces(Long groupId) {


### PR DESCRIPTION
## 📄 설명

- RuntimeException에 대해 에러 메시지를 응답하도록 처리
- 그룹 중복 가입을 막는 검증 로직 추가 

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- 

## 🔒 이슈 닫기

- resolved: #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - API errors now return a consistent, user-friendly message format across endpoints.
- Bug Fixes
  - Prevents joining the same group multiple times; users already in a group receive a clear notice instead of being re-added.
  - More reliable responses when using invite codes, avoiding duplicate memberships and improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->