### PR TITLE
로그인 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/team1/allo/auth/controller/AuthController.java
+++ b/src/main/java/team1/allo/auth/controller/AuthController.java
@@ -1,15 +1,20 @@
 package team1.allo.auth.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import team1.allo.auth.annotation.Auth;
 import team1.allo.auth.service.AuthService;
 import team1.allo.auth.service.dto.KakaoLoginRequest;
 import team1.allo.auth.service.dto.LoginResponse;
+import team1.allo.auth.service.dto.MyProfileResponse;
+import team1.allo.member.entity.Member;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -23,4 +28,9 @@ public class AuthController {
 		return authService.login(request.accessToken());
 	}
 
+	@Operation(summary = "로그인 사용자 정보 조회")
+	@GetMapping("/me")
+	public MyProfileResponse getMyProfile(@Parameter(hidden = true) @Auth Member member) {
+		return authService.getMyProfile(member);
+	}
 }

--- a/src/main/java/team1/allo/auth/service/AuthService.java
+++ b/src/main/java/team1/allo/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import team1.allo.auth.client.KakaoClient;
 import team1.allo.auth.jwt.JwtProvider;
 import team1.allo.auth.service.dto.KakaoUserResponse;
 import team1.allo.auth.service.dto.LoginResponse;
+import team1.allo.auth.service.dto.MyProfileResponse;
 import team1.allo.member.entity.Member;
 import team1.allo.member.repository.MemberRepository;
 
@@ -38,6 +39,10 @@ public class AuthService {
 
 		String jwt = jwtProvider.generateToken(member.getId());
 		return new LoginResponse("Bearer " + jwt);
+	}
+
+	public MyProfileResponse getMyProfile(Member member) {
+		return MyProfileResponse.from(member);
 	}
 }
 

--- a/src/main/java/team1/allo/auth/service/AuthService.java
+++ b/src/main/java/team1/allo/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import team1.allo.auth.jwt.JwtProvider;
 import team1.allo.auth.service.dto.KakaoUserResponse;
 import team1.allo.auth.service.dto.LoginResponse;
 import team1.allo.auth.service.dto.MyProfileResponse;
+import team1.allo.group.service.generator.InviteCodeGenerator;
 import team1.allo.member.entity.Member;
 import team1.allo.member.repository.MemberRepository;
 
@@ -18,6 +19,7 @@ public class AuthService {
 	private final KakaoClient kakaoClient;
 	private final MemberRepository memberRepository;
 	private final JwtProvider jwtProvider;
+	private final InviteCodeGenerator inviteCodeGenerator;
 
 	public LoginResponse login(String kakaoAccessToken) {
 		// WebClient 호출을 동기(blocking)으로 받음
@@ -29,10 +31,12 @@ public class AuthService {
 
 		Long kakaoId = userInfo.id();
 		String code = "KAKAO_" + kakaoId;
+		String name = "allo_" + inviteCodeGenerator.generateInviteCode();
 
 		Member member = memberRepository.findByCode(code)
 			.orElse(Member.builder()
 				.code(code)
+				.name(name)
 				.build());
 
 		member = memberRepository.save(member);

--- a/src/main/java/team1/allo/auth/service/dto/MyProfileResponse.java
+++ b/src/main/java/team1/allo/auth/service/dto/MyProfileResponse.java
@@ -1,0 +1,18 @@
+package team1.allo.auth.service.dto;
+
+import team1.allo.member.entity.Member;
+
+public record MyProfileResponse(
+	Long memberId,
+	String memberNickName,
+	String memberProfileImageUrl
+) {
+
+	public static MyProfileResponse from(Member member) {
+		return new MyProfileResponse(
+			member.getId(),
+			member.getName(),
+			member.getProfileImageUrl()
+		);
+	}
+}


### PR DESCRIPTION
## 📄 설명

- 로그인 사용자 정보 조회 API 구현
- 첫 로그인 시 닉네임에 null 대신 임시 문자열을 지정

## ✔️ 작업한 내용

<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->

- 

## 🔒 이슈 닫기

- resolved: #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GET /api/auth/me endpoint to retrieve the currently authenticated user’s profile (ID, nickname, profile image URL).
  * First-time Kakao sign-ins now receive an auto-generated unique nickname to streamline onboarding.

* **Improvements**
  * Enhanced authentication flow to expose a simple profile retrieval path for logged-in users.

* **Chores**
  * Internal updates to support profile responses and nickname generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->